### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -1,4 +1,6 @@
 name: Update Notion Movies
+permissions:
+  contents: read
 
 on:
    schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/jdmartinez/notion-movie-updater/security/code-scanning/1](https://github.com/jdmartinez/notion-movie-updater/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow that grants only the minimal privileges required. In this case, the workflow merely checks out code, caches dependencies, builds, and runs a .NET application, so `contents: read` is sufficient. The least intrusive fix is to place the `permissions` key at the root level (directly under the workflow `name:` and before `on:`), so that it applies to all jobs unless individually overridden. The change is a single addition of a few lines near the top of `.github/workflows/run.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
