### PR TITLE
chore: revert Notion.Net package version to 4.4.0

### DIFF
--- a/src/NotionMovieUpdater/NotionMovieUpdater.csproj
+++ b/src/NotionMovieUpdater/NotionMovieUpdater.csproj
@@ -22,7 +22,7 @@
       <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
-      <PackageReference Include="Notion.Net" Version="5.0.0" />
+      <PackageReference Include="Notion.Net" Version="4.4.0" />
       <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     </ItemGroup>
 


### PR DESCRIPTION
Revert `Notion.Net` package version to `4.4.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an app dependency to an earlier version to improve compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->